### PR TITLE
Consistent with SCons' can_build() only taking 1 argument now

### DIFF
--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -1,4 +1,4 @@
-def can_build(env, platform):
+def can_build(platform):
   return platform=="x11" or platform=="windows" or platform=="osx"
 
 def configure(env):


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/22195, same issue caused by a different module(GodotSteam rather than ARVR)